### PR TITLE
Fix Test Case 9, 10, 11, 17 (non-HTTPS calls) timeout logic

### DIFF
--- a/src/__tests__/lambda/runTestCases.test.ts
+++ b/src/__tests__/lambda/runTestCases.test.ts
@@ -247,6 +247,58 @@ describe("runTestCases Lambda handler general tests", () => {
     expect(body.passingPercentage).toBe(expectedPassingPercentage);
   });
 
+  test("should mark timeout errors as successful if ignoreTimeoutErrors is true", async () => {
+// Arrange
+    const event = createEvent({
+      baseUrl: mockBaseUrl,
+      clientId: "client-id",
+      clientSecret: "client-secret",
+      version: "V2.2",
+      companyName: "Test Company",
+      adminEmail: "admin@test.com",
+      adminName: "Admin Test",
+    });
+
+    // Mock test case #4 to fail
+    (runTestCaseModule.runTestCase as jest.Mock).mockImplementation(
+      (baseUrl, testCase) => {
+        if (testCase.ignoreTimeoutErrors === true) {
+          return Promise.resolve({
+            name: testCase.name,
+            status: TestResultStatus.SUCCESS,
+            success: true,
+            errorMessage: "Test failed",
+            mandatory: true,
+            testKey: testCase.testKey,
+          });
+        }
+        return Promise.resolve({
+          name: testCase.name,
+          status: TestResultStatus.SUCCESS,
+          success: true,
+          mandatory: true,
+          testKey: testCase.testKey,
+        });
+      }
+    );
+
+    // Act
+    const result = await handler(event);
+
+    // Assert
+    expect(result.statusCode).toBe(500);
+    const body = JSON.parse(result.body);
+    expect(body.message).toBe("One or more tests failed");
+
+    // Calculate expected passing percentage (18/19 tests passed = ~94.7%)
+    const totalMandatoryTests = 18;
+    const failedMandatoryTests = 1;
+    const expectedPassingPercentage = Math.round(
+      ((totalMandatoryTests - failedMandatoryTests) / totalMandatoryTests) * 100
+    );
+    expect(body.passingPercentage).toBe(expectedPassingPercentage);    
+  });      
+
   test("should handle missing request body fields", async () => {
     // Arrange - create an event with missing required fields
     const event = createEvent({

--- a/src/__tests__/lambda/runTestCases.test.ts
+++ b/src/__tests__/lambda/runTestCases.test.ts
@@ -247,58 +247,6 @@ describe("runTestCases Lambda handler general tests", () => {
     expect(body.passingPercentage).toBe(expectedPassingPercentage);
   });
 
-  test("should mark timeout errors as successful if ignoreTimeoutErrors is true", async () => {
-// Arrange
-    const event = createEvent({
-      baseUrl: mockBaseUrl,
-      clientId: "client-id",
-      clientSecret: "client-secret",
-      version: "V2.2",
-      companyName: "Test Company",
-      adminEmail: "admin@test.com",
-      adminName: "Admin Test",
-    });
-
-    // Mock test case #4 to fail
-    (runTestCaseModule.runTestCase as jest.Mock).mockImplementation(
-      (baseUrl, testCase) => {
-        if (testCase.ignoreTimeoutErrors === true) {
-          return Promise.resolve({
-            name: testCase.name,
-            status: TestResultStatus.SUCCESS,
-            success: true,
-            errorMessage: "Test failed",
-            mandatory: true,
-            testKey: testCase.testKey,
-          });
-        }
-        return Promise.resolve({
-          name: testCase.name,
-          status: TestResultStatus.SUCCESS,
-          success: true,
-          mandatory: true,
-          testKey: testCase.testKey,
-        });
-      }
-    );
-
-    // Act
-    const result = await handler(event);
-
-    // Assert
-    expect(result.statusCode).toBe(500);
-    const body = JSON.parse(result.body);
-    expect(body.message).toBe("One or more tests failed");
-
-    // Calculate expected passing percentage (18/19 tests passed = ~94.7%)
-    const totalMandatoryTests = 18;
-    const failedMandatoryTests = 1;
-    const expectedPassingPercentage = Math.round(
-      ((totalMandatoryTests - failedMandatoryTests) / totalMandatoryTests) * 100
-    );
-    expect(body.passingPercentage).toBe(expectedPassingPercentage);    
-  });      
-
   test("should handle missing request body fields", async () => {
     // Arrange - create an event with missing required fields
     const event = createEvent({

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -41,6 +41,7 @@ export interface TestCase {
   mandatoryVersion?: ApiVersion[];
   testKey: string;
   documentationUrl?: string;
+  ignoreTimeoutErrors?: boolean;
 }
 export interface TestResult {
   name: string;

--- a/src/utils/runTestCase.test.ts
+++ b/src/utils/runTestCase.test.ts
@@ -1,0 +1,372 @@
+import { jest } from "@jest/globals";
+import { runTestCase } from "./runTestCase";
+import { TestResultStatus } from "../types/types";
+
+type AnyObj = Record<string, any>;
+
+const BASE_URL = "https://api.example.com";
+const ACCESS_TOKEN = "test-access-token";
+const VERSION = "v1";
+
+const makeHeaders = (obj: Record<string, string> = {}) => ({
+  get: (k: string) => (k in obj ? obj[k] : null),
+  has: (k: string) => k in obj,
+});
+
+const mockFetchOk = (
+  status = 200,
+  body = "",
+  headers: Record<string, string> = {}
+) => {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    status,
+    text: jest.fn().mockResolvedValue(body as never),
+    headers: makeHeaders(headers),
+  } as never);
+};
+
+const mockFetchReject = (error: any) => {
+  (global.fetch as jest.Mock).mockRejectedValue(error as never);
+};
+
+describe("runTestCase", () => {
+  beforeAll(() => {
+    // Silence module logs in tests
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    // Ensure AbortSignal.timeout exists for the request path
+    if (!(AbortSignal as AnyObj).timeout) {
+      (AbortSignal as AnyObj).timeout = (ms: number) => {
+        const c = new AbortController();
+        setTimeout(() => c.abort(), ms);
+        return c.signal;
+      };
+    }
+  });
+
+  beforeEach(() => {
+    (global as AnyObj).fetch = jest.fn();
+    jest.clearAllMocks();
+  });
+
+  it("fails when neither endpoint nor customUrl is provided", async () => {
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "missing-url",
+        method: "GET",
+        // no endpoint, no customUrl
+        testKey: "T-1",
+        documentationUrl: "https://docs.example.com/t-1",
+        mandatoryVersion: ["v1", "v2"],
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    expect(res.errorMessage).toBe(
+      "Either endpoint or customUrl must be provided"
+    );
+    expect(res.curlRequest).toBe("N/A - Missing URL");
+    expect(res.mandatory).toBe(true); // version is in mandatoryVersion
+  });
+
+  it("happy path: GET, endpoint, 200 OK, no schema/condition", async () => {
+    mockFetchOk(200, JSON.stringify({ ok: true }));
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "simple-get",
+        method: "GET",
+        endpoint: "/health",
+        expectedStatusCodes: [200],
+        testKey: "T-2",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe(`${BASE_URL}/health`);
+    expect((options as RequestInit).method).toBe("GET");
+    expect((options as any).headers["Content-Type"]).toBe("application/json");
+    expect((options as any).headers["Authorization"]).toBe(
+      `Bearer ${ACCESS_TOKEN}`
+    );
+    expect((options as RequestInit).body).toBeUndefined();
+
+    expect(res.success).toBe(true);
+    expect(res.status).toBe(TestResultStatus.SUCCESS);
+    // Curl contains method, URL, auth header, content-type; no -d
+    expect(res.curlRequest).toContain(
+      "curl -X GET 'https://api.example.com/health'"
+    );
+    expect(res.curlRequest).toContain(
+      " -H 'Authorization: Bearer test-access-token'"
+    );
+    expect(res.curlRequest).toContain(" -H 'Content-Type: application/json'");
+    expect(res.curlRequest).not.toContain(" -d '");
+  });
+
+  it("uses customUrl over baseUrl+endpoint and merges/overrides headers; string body appears in curl", async () => {
+    mockFetchOk(200, "");
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "custom-url-post",
+        method: "POST",
+        customUrl: "https://alt.example.net/echo",
+        requestData: "raw-body",
+        headers: {
+          "Content-Type": "text/plain", // overrides default
+          "X-Test": "1",
+        },
+        expectedStatusCodes: [200],
+        testKey: "T-3",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe("https://alt.example.net/echo");
+    expect((options as any).method).toBe("POST");
+    // overridden header persists
+    expect((options as any).headers["Content-Type"]).toBe("text/plain");
+    expect((options as any).headers["X-Test"]).toBe("1");
+    expect((options as any).body).toBe("raw-body");
+
+    // Curl contains headers & -d; order-insensitive checks
+    expect(res.curlRequest).toContain(
+      "curl -X POST 'https://alt.example.net/echo'"
+    );
+    expect(res.curlRequest).toContain(
+      " -H 'Authorization: Bearer test-access-token'"
+    );
+    expect(res.curlRequest).toContain(" -H 'Content-Type: text/plain'");
+    expect(res.curlRequest).toContain(" -H 'X-Test: 1'");
+    expect(res.curlRequest).toContain(" -d 'raw-body'");
+    expect(res.success).toBe(true);
+  });
+
+  it("fails when expectedStatusCodes do not include actual status", async () => {
+    mockFetchOk(200, "{}");
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "status-mismatch",
+        method: "GET",
+        endpoint: "/created",
+        expectedStatusCodes: [201],
+        testKey: "T-4",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    expect(res.errorMessage).toBe("Expected status [201], but got 200");
+  });
+
+  it("parses JSON; invalid JSON triggers failure in catch", async () => {
+    mockFetchOk(200, "not-json");
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "invalid-json",
+        method: "GET",
+        endpoint: "/bad-json",
+        expectedStatusCodes: [200],
+        testKey: "T-5",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    // Engine-specific message, keep assertion tolerant:
+    expect(res.errorMessage).toMatch(/Unexpected|JSON/i);
+  });
+
+  it("schema validation fails when response violates schema", async () => {
+    mockFetchOk(200, JSON.stringify({ id: "oops" }));
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "schema-fail",
+        method: "GET",
+        endpoint: "/schema",
+        expectedStatusCodes: [200],
+        schema: {
+          type: "object",
+          properties: { id: { type: "number" } },
+          required: ["id"],
+          additionalProperties: false,
+        },
+        testKey: "T-6",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    expect(res.errorMessage).toContain("Schema validation failed:");
+    expect(res.apiResponse).toBe(JSON.stringify({ id: "oops" }));
+  });
+
+  it("schema validation passes and condition passes -> success", async () => {
+    mockFetchOk(200, JSON.stringify({ id: "abc" }), { "x-flag": "ok" });
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "schema-ok-condition-ok",
+        method: "GET",
+        endpoint: "/ok",
+        expectedStatusCodes: [200],
+        schema: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+          additionalProperties: false,
+        },
+        condition: (data: any, headers: any) =>
+          data.id === "abc" && headers.get("x-flag") === "ok",
+        testKey: "T-7",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.status).toBe(TestResultStatus.SUCCESS);
+  });
+
+  it("condition fails -> failure with provided conditionErrorMessage", async () => {
+    mockFetchOk(200, JSON.stringify({ id: 1 }));
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "condition-fail",
+        method: "GET",
+        endpoint: "/cond",
+        expectedStatusCodes: [200],
+        condition: () => false,
+        conditionErrorMessage: "Condition failed!",
+        testKey: "T-8",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    expect(res.errorMessage).toBe("Condition failed!");
+    expect(res.apiResponse).toBe(JSON.stringify({ id: 1 }));
+  });
+
+  it("timeout error returns SUCCESS when ignoreTimeoutErrors is true", async () => {
+    mockFetchReject({ name: "AbortError", message: "aborted" });
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "timeout-ignored",
+        method: "GET",
+        endpoint: "/slow",
+        expectedStatusCodes: [200],
+        ignoreTimeoutErrors: true,
+        testKey: "T-9",
+        mandatoryVersion: ["v2"], // not current version -> false
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.status).toBe(TestResultStatus.SUCCESS);
+    // default timeout is 5000ms unless env overrides at module-load time
+    expect(res.errorMessage).toBe("Request timeout after 5000ms");
+    expect(res.mandatory).toBe(false);
+  });
+
+  it("timeout error returns FAILURE when ignoreTimeoutErrors is false/omitted", async () => {
+    mockFetchReject({ name: "AbortError", message: "aborted" });
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "timeout-fail",
+        method: "GET",
+        endpoint: "/slow",
+        expectedStatusCodes: [200],
+        testKey: "T-10",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(false);
+    expect(res.status).toBe(TestResultStatus.FAILURE);
+    expect(res.errorMessage).toBe("Request timeout after 5000ms");
+  });
+
+  it("no expectedStatusCodes: non-200 can still succeed (schema/condition absent)", async () => {
+    mockFetchOk(503, "");
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "no-expected-codes",
+        method: "GET",
+        endpoint: "/maybe",
+        // expectedStatusCodes omitted
+        testKey: "T-11",
+        mandatoryVersion: ["v1"], // current version -> true
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    expect(res.success).toBe(true);
+    expect(res.status).toBe(TestResultStatus.SUCCESS);
+    expect(res.mandatory).toBe(true);
+  });
+
+  it("object requestData is JSON-stringified and appears in curl -d", async () => {
+    mockFetchOk(200, "{}");
+
+    const payload = { a: 1, b: "x" };
+
+    const res = await runTestCase(
+      BASE_URL,
+      {
+        name: "json-body",
+        method: "POST",
+        endpoint: "/items",
+        requestData: payload,
+        expectedStatusCodes: [200],
+        headers: { "X-Trace": "on" },
+        testKey: "T-12",
+      } as any,
+      ACCESS_TOKEN,
+      VERSION as any
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect((options as Response).body).toBe(JSON.stringify(payload));
+    expect(res.curlRequest).toContain(` -d '${JSON.stringify(payload)}'`);
+    expect(res.curlRequest).toContain(" -H 'X-Trace: on'");
+  });
+});

--- a/src/utils/runTestCase.ts
+++ b/src/utils/runTestCase.ts
@@ -192,6 +192,20 @@ export const runTestCase = async (
       ? `Request timeout after ${DEFAULT_FETCH_TIMEOUT_MS}ms`
       : error.message;
 
+    // #127: Handle timeout errors based on ignoreTimeoutErrors flag
+    if (isTimeoutError && testCase.ignoreTimeoutErrors) {
+      return {
+        name: testCase.name,
+        status: TestResultStatus.SUCCESS,
+        success: true,
+        errorMessage: errorMessage,
+        mandatory: isMandatoryVersion(testCase, version),
+        testKey: testCase.testKey,
+        curlRequest: curlCmd,
+        documentationUrl: testCase.documentationUrl,
+      };
+    }
+
     return {
       name: testCase.name,
       status: TestResultStatus.FAILURE,


### PR DESCRIPTION
Fixes #127 by adding a new property to the TestCase which allows it to safely ignore timeout errors